### PR TITLE
Allow to add instances of type "Link" to playlist.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -63,6 +63,18 @@ Initial playlist
 
 An initial playlist with tracks is created at /playlist.
 
+Multiple playlists
+------------------
+
+Create additional playlists. The player takes the one with the newest publishing date.
+
+Where are the audio files?
+--------------------------
+
+- You can add tracks with audio files to a playlist.
+- You can reference audio files with links.
+- You can reference external audio files with links via remote url.
+
 Sticky Footer
 -------------
 

--- a/news/5.breaking
+++ b/news/5.breaking
@@ -1,0 +1,2 @@
+- Audio files can stay remote and are referenced in a playlist with links.
+    Also on site audios can be referenced by links [ksuess]

--- a/src/collective/playlist/browser/templates/playerfooterviewlet.pt
+++ b/src/collective/playlist/browser/templates/playerfooterviewlet.pt
@@ -1,5 +1,5 @@
-<tal:playerfooterviewlet tal:condition="view/show">    
+<tal:playerfooterviewlet tal:condition="view/show">
     <div id="playerfooterviewlet">
-        <div tal:content="structure context/playlist/@@playlistfooterview"></div>
+        <div tal:content="structure view/playlist/@@playlistfooterview"></div>
     </div>
 </tal:playerfooterviewlet>

--- a/src/collective/playlist/browser/viewlets.py
+++ b/src/collective/playlist/browser/viewlets.py
@@ -35,6 +35,7 @@ class PlaylistFooterViewlet(PlaylistButtonViewlet):
     """
     """
 
+    @property
     def playlist(self):
         result = self._playlists()[0].getObject()
         return result

--- a/src/collective/playlist/browser/views.py
+++ b/src/collective/playlist/browser/views.py
@@ -35,25 +35,47 @@ class PlaylistBaseView(DefaultView):
 
         context = self.context
         items = context.contentItems()
-        tracks = [item for item in items if (item[1].portal_type == 'track' and
+        tracks = [item for item in items if (item[1].portal_type in ['track', 'Link'] and
                                              api.content.get_state(obj=item[1]) == 'published')]
         tracklist = []
         for tr in tracks:
             title = tr[1].title
-            format = tr[1].audiofile.filename.split('.')[-1]
-            format = format in ALLOWED_AUDIOTYPES and format or 'mp3'
-            address = '/'.join([context.absolute_url(),
+            if tr[1].portal_type == 'track':
+                filename = tr[1].audiofile.filename
+                address = '/'.join([context.absolute_url(),
                                 tr[0],
                                 '@@download/audiofile',
-                                tr[1].audiofile.filename])
+                                filename])
+                format = filename.split('.')[-1]
+                format = format in ALLOWED_AUDIOTYPES and format or 'mp3'
+            elif tr[1].portal_type == 'Link':
+                remoteUrl = tr[1].remoteUrl
+                if remoteUrl.startswith("${portal_url}"):
+                    obj = api.content.get(UID=remoteUrl.split("/")[-1])
+                    try:
+                        filename = obj.file.filename
+                    except Exception as e:
+                        logger.error("*** getTracks. Link auf non audio file. ({})".format(e))
+                        continue
+                    address = '/'.join([obj.absolute_url(),
+                                    '@@download/file',
+                                    filename])
+                    format = filename.split('.')[-1]
+                    format = format in ALLOWED_AUDIOTYPES and format or 'mp3'
+                else:
+                    address = remoteUrl
+                format = address.split('.')[-1]
+                format = format in ALLOWED_AUDIOTYPES and format or 'mp3'
+            else: continue
             tracklist.append({'title': title, format: address})
+        logger.info("tracklist {}".format(tracklist))
         return tracklist
 
     def getJSONTracks(self):
         """ list of json track dictionaries
         """
         return json.dumps(self.getTracks())
-        
+
     def can_add_and_edit(self):
         # todo: remove after fix of robottests bug
         try:
@@ -104,7 +126,7 @@ class PlaylistPopupView(PlaylistBaseView):
 
     def __call__(self):
         return self.template()
-    
+
 
 class PlaylistFooterView(PlaylistBaseView):
     """

--- a/src/collective/playlist/profiles/default/types/playlist.xml
+++ b/src/collective/playlist/profiles/default/types/playlist.xml
@@ -21,6 +21,7 @@
  <property name="filter_content_types">True</property>
  <property name="allowed_content_types">
     <element value="track"/>
+    <element value="Link"/>
  </property>
   <property name="global_allow">True</property>
 


### PR DESCRIPTION
Before, playlists contained tracks, which hold one file per track. Now the audio files can stay remote and are referenced in a playlist. This is additional to the former track that delivers one audio file.
See https://github.com/collective/collective.playlist/issues/2